### PR TITLE
Update metadata description on Web Server API page

### DIFF
--- a/web-api/index.rst
+++ b/web-api/index.rst
@@ -2,8 +2,8 @@ Web Server API
 ==============
 
 .. seo::
-    :description: Migration guide for installing ESPHome on ESPs running ESPEasy.
-    :image: espeasy.svg
+    :description: Information on Web Server APIs, including Event Source APIs and REST APIs.
+    :image: logo-text.svg
 
 Since version 1.3, ESPHome includes a built-in web server that can be used to view states
 and send commands. In addition to the web-frontend available under the root index of the


### PR DESCRIPTION
## Description:

Change metadata description from the wrong description: Migration guide for installing ESPHome on ESPs running ESPEasy.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
